### PR TITLE
Add Docling-based PDF reading skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you want to run it manually, this is the one command most people need:
 
 | Skill | Audience | What it does | Path |
 |---|---|---|---|
+| `pdf-reading` | General | Docling-first PDF reading with optional figure, image, and table extraction artifacts | `skills/general/pdf-reading` |
 | `python-learning-coach` | General | Personalized Python tutoring with memory, daily logs, and level adaptation | `skills/general/python-learning-coach` |
 
 ## Install Options
@@ -66,7 +67,7 @@ chmod +x scripts/bootstrap.sh
 ### 4) Install only selected skills
 
 ```bash
-./scripts/bootstrap.sh --target both --scope global --skills python-learning-coach
+./scripts/bootstrap.sh --target both --scope global --skills pdf-reading
 ```
 
 ### 5) Install by category/type

--- a/skills/general/pdf-reading/SKILL.md
+++ b/skills/general/pdf-reading/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: pdf-reading
+description: Read, summarize, search, and extract structured artifacts from PDF files, especially papers and reports. Use when the user wants a PDF converted before reading, needs figures or tables pulled out, wants image labels or captions, or needs cleaner Markdown/text than reading the PDF directly.
+---
+
+# PDF Reading
+
+Use this skill for PDF-first work on papers and reports. The default path is Docling-first.
+
+## Rules
+
+- Never read a PDF directly. Convert it first, then read the generated artifact.
+- Default to Docling for reading. Use `--fast` only when the user explicitly prefers speed over fidelity.
+- Extract figures or tables only when the user asks for them or when the answer depends on them.
+- For tables, prefer the cleaned Markdown for quick review, but inspect the crop image when numeric fidelity matters.
+- If values or labels look suspicious, cite the crop or page artifact rather than trusting the structured export.
+- If Docling fails, fall back to `pdftotext -layout` and continue with a degraded-quality warning.
+
+## Quick Start
+
+Run the extractor on a PDF:
+
+```bash
+python3 scripts/pdf_extract.py /path/to/paper.pdf
+```
+
+Extract figures with structural labels:
+
+```bash
+python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures
+```
+
+Extract figures with richer descriptions instead of classifier labels:
+
+```bash
+python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --figure-label-mode description
+```
+
+Extract tables, cleaned Markdown, CSV, and crop images:
+
+```bash
+python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-tables
+```
+
+Extract both figures and tables:
+
+```bash
+python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --extract-tables
+```
+
+Use the faster MarkItDown path only when requested:
+
+```bash
+python3 scripts/pdf_extract.py /path/to/paper.pdf --fast
+```
+
+## Outputs
+
+- `<basename>.docling.md`: primary reading artifact from Docling.
+- `<basename>.layout.txt`: fallback text artifact when Docling fails.
+- `<basename>.docling_artifacts/`: extracted figure images referenced by Markdown.
+- `<basename>.figures.json`: figure metadata, labels, captions, and image paths.
+- `<basename>.tables/`: raw and cleaned table Markdown, CSV exports, and crop images.
+- `<basename>.tables.json`: table metadata and verification flags.
+
+The script prints a JSON summary with the exact artifact paths to read next.

--- a/skills/general/pdf-reading/agents/openai.yaml
+++ b/skills/general/pdf-reading/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PDF Reading"
+  short_description: "Docling-first PDF reading with artifacts."
+  default_prompt: "Use $pdf-reading to convert this PDF before reading it, and extract figures or tables if they matter."

--- a/skills/general/pdf-reading/scripts/pdf_extract.py
+++ b/skills/general/pdf-reading/scripts/pdf_extract.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from table_cleanup import clean_table_markdown
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert PDFs into readable Markdown and optional figure/table artifacts.")
+    parser.add_argument("pdf", help="Path to the source PDF.")
+    parser.add_argument("--extract-figures", action="store_true", help="Extract figure images and write figures.json.")
+    parser.add_argument(
+        "--figure-label-mode",
+        choices=("classification", "description", "none"),
+        default="classification",
+        help="How figure labels should be added to Markdown and figures.json.",
+    )
+    parser.add_argument("--extract-tables", action="store_true", help="Extract tables, cleaned Markdown, CSV, and crop images.")
+    parser.add_argument(
+        "--table-cleanup",
+        choices=("normal", "off"),
+        default="normal",
+        help="Whether to run readability cleanup on exported table Markdown.",
+    )
+    parser.add_argument("--fast", action="store_true", help="Use MarkItDown instead of Docling for the read artifact.")
+    parser.add_argument("--force", action="store_true", help="Ignore cache and regenerate outputs.")
+    return parser.parse_args()
+
+
+def _uv_bootstrap(args: argparse.Namespace) -> None:
+    if os.environ.get("PDF_READING_UV_BOOTSTRAPPED") == "1":
+        return
+
+    docling_missing = False
+    markitdown_missing = False
+
+    if not args.fast or args.extract_figures or args.extract_tables:
+        try:
+            import docling  # noqa: F401
+        except ImportError:
+            docling_missing = True
+
+    if args.fast:
+        try:
+            import markitdown  # noqa: F401
+        except ImportError:
+            markitdown_missing = True
+
+    if not docling_missing and not markitdown_missing:
+        return
+
+    uv = shutil.which("uv")
+    if uv is None:
+        missing = []
+        if docling_missing:
+            missing.append("docling")
+        if markitdown_missing:
+            missing.append("markitdown[pdf]")
+        raise SystemExit(f"Missing dependencies: {', '.join(missing)}. Install them or install uv first.")
+
+    cmd = [uv, "run"]
+    if docling_missing or args.extract_figures or args.extract_tables or not args.fast:
+        cmd.extend(["--with", "docling"])
+    if markitdown_missing or args.fast:
+        cmd.extend(["--with", "markitdown[pdf]"])
+    cmd.extend(["python", str(Path(__file__).resolve()), *sys.argv[1:]])
+    env = os.environ.copy()
+    env["PDF_READING_UV_BOOTSTRAPPED"] = "1"
+    raise SystemExit(subprocess.call(cmd, env=env))
+
+
+def _sanitize_description(text: str | None) -> str | None:
+    if not text:
+        return None
+    cleaned = text.strip()
+    cleaned = re.sub(r"<end_of_utteranc.*$", "", cleaned).strip()
+    cleaned = re.sub(r"<\|.*?\|>", "", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned or None
+
+
+def _sanitize_markdown_artifacts(markdown: str) -> str:
+    cleaned = re.sub(r"<end_of_utteranc[^ \n]*", "", markdown)
+    cleaned = re.sub(r"<\|.*?\|>", "", cleaned)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    return cleaned
+
+
+def _parse_table_title(table_markdown: str) -> str | None:
+    for line in table_markdown.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("|"):
+            return None
+        return stripped
+    return None
+
+
+def _json_dump(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _is_fresh(pdf_path: Path, sentinels: list[Path]) -> bool:
+    if not sentinels:
+        return False
+    if not all(path.exists() for path in sentinels):
+        return False
+    pdf_mtime = pdf_path.stat().st_mtime
+    return all(path.stat().st_mtime >= pdf_mtime for path in sentinels)
+
+
+def _build_summary(
+    pdf_path: Path,
+    read_artifact: Path,
+    engine: str,
+    cached: bool,
+    figures_json: Path | None,
+    tables_json: Path | None,
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "source_pdf": str(pdf_path),
+        "read_artifact": str(read_artifact),
+        "engine": engine,
+        "cached": cached,
+    }
+    if figures_json is not None:
+        summary["figures_manifest"] = str(figures_json)
+    if tables_json is not None:
+        summary["tables_manifest"] = str(tables_json)
+    return summary
+
+
+def _run_markitdown(pdf_path: Path, output_path: Path) -> Path:
+    from markitdown import MarkItDown
+
+    result = MarkItDown().convert(str(pdf_path))
+    output_path.write_text(result.text_content, encoding="utf-8")
+    return output_path
+
+
+def _run_pdftotext(pdf_path: Path, output_path: Path) -> Path:
+    pdftotext = shutil.which("pdftotext")
+    if pdftotext is None:
+        raise RuntimeError("Docling failed and pdftotext is unavailable for fallback.")
+    subprocess.run([pdftotext, "-layout", str(pdf_path), str(output_path)], check=True)
+    return output_path
+
+
+def _rename_docling_artifacts(md_path: Path, artifacts_dir: Path, label_prefix: str = "figure") -> list[Path]:
+    markdown = md_path.read_text(encoding="utf-8")
+    generated = sorted(path for path in artifacts_dir.iterdir() if path.is_file())
+    renamed: list[Path] = []
+
+    for index, old_path in enumerate(generated, start=1):
+        new_name = f"{label_prefix}_{index:03d}{old_path.suffix.lower()}"
+        new_path = artifacts_dir / new_name
+        if old_path != new_path:
+            old_path.replace(new_path)
+        new_ref = f"{artifacts_dir.name}/{new_path.name}"
+        markdown = markdown.replace(str(old_path), new_ref)
+        markdown = markdown.replace(old_path.as_posix(), new_ref)
+        markdown = markdown.replace(f"{artifacts_dir.name}/{old_path.name}", new_ref)
+        renamed.append(new_path)
+
+    markdown = _sanitize_markdown_artifacts(markdown)
+    md_path.write_text(markdown, encoding="utf-8")
+    return renamed
+
+
+def _extract_figures(doc: Any, pdf_path: Path, artifacts_dir: Path, figures_json: Path, renamed_artifacts: list[Path]) -> None:
+    figures: list[dict[str, Any]] = []
+    for index, picture in enumerate(doc.pictures, start=1):
+        page_no = None
+        if getattr(picture, "prov", None):
+            page_no = getattr(picture.prov[0], "page_no", None)
+
+        description = None
+        top_label = None
+        top_confidence = None
+        if getattr(picture, "meta", None) is not None:
+            description = _sanitize_description(getattr(getattr(picture.meta, "description", None), "text", None))
+            classification = getattr(picture.meta, "classification", None)
+            if classification and getattr(classification, "predictions", None):
+                top_prediction = classification.predictions[0]
+                top_label = top_prediction.class_name
+                top_confidence = round(float(top_prediction.confidence), 3)
+
+        image_path = None
+        if index <= len(renamed_artifacts):
+            image_path = renamed_artifacts[index - 1]
+
+        figures.append(
+            {
+                "id": index,
+                "page": page_no,
+                "caption": picture.caption_text(doc) or None,
+                "label": top_label,
+                "label_confidence": top_confidence,
+                "description": description,
+                "image_path": str(image_path) if image_path is not None else None,
+            }
+        )
+
+    _json_dump(figures_json, figures)
+
+
+def _extract_tables(doc: Any, tables_dir: Path, tables_json: Path, table_cleanup_mode: str) -> None:
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    manifest: list[dict[str, Any]] = []
+
+    for index, table in enumerate(doc.tables, start=1):
+        prefix = f"table_{index:03d}"
+        raw_md_path = tables_dir / f"{prefix}.raw.md"
+        cleaned_md_path = tables_dir / f"{prefix}.cleaned.md"
+        crop_path = tables_dir / f"{prefix}.crop.png"
+        csv_path = tables_dir / f"{prefix}.csv"
+
+        raw_markdown = table.export_to_markdown(doc=doc)
+        raw_md_path.write_text(raw_markdown, encoding="utf-8")
+
+        cleanup_report = None
+        cleaned_markdown = raw_markdown
+        if table_cleanup_mode == "normal":
+            cleaned_markdown, cleanup_report = clean_table_markdown(raw_markdown)
+        cleaned_md_path.write_text(cleaned_markdown, encoding="utf-8")
+
+        csv_output = None
+        try:
+            dataframe = table.export_to_dataframe(doc=doc)
+            dataframe.to_csv(csv_path, index=False)
+            csv_output = csv_path
+        except Exception:
+            csv_output = None
+
+        crop_saved = None
+        try:
+            crop = table.get_image(doc)
+            if crop is not None:
+                crop.save(crop_path)
+                crop_saved = crop_path
+        except Exception:
+            crop_saved = None
+
+        page_no = None
+        if getattr(table, "prov", None):
+            page_no = getattr(table.prov[0], "page_no", None)
+
+        if cleanup_report is None:
+            _, cleanup_report = clean_table_markdown(raw_markdown)
+
+        manifest.append(
+            {
+                "id": index,
+                "page": page_no,
+                "title": _parse_table_title(raw_markdown),
+                "raw_markdown_path": str(raw_md_path),
+                "cleaned_markdown_path": str(cleaned_md_path),
+                "csv_path": str(csv_output) if csv_output is not None else None,
+                "crop_path": str(crop_saved) if crop_saved is not None else None,
+                "verification_required": cleanup_report.verification_required,
+                "verification_reasons": cleanup_report.reasons,
+                "cleanup_report": asdict(cleanup_report),
+            }
+        )
+
+    _json_dump(tables_json, manifest)
+
+
+def _run_docling(
+    args: argparse.Namespace,
+    pdf_path: Path,
+    md_path: Path,
+    artifacts_dir: Path,
+    figures_json: Path | None,
+    tables_dir: Path | None,
+    tables_json: Path | None,
+) -> Path:
+    from docling.datamodel.base_models import InputFormat
+    from docling.datamodel.pipeline_options import PdfPipelineOptions
+    from docling.document_converter import DocumentConverter, PdfFormatOption
+    from docling_core.types.doc import ImageRefMode
+
+    options = PdfPipelineOptions()
+    options.generate_picture_images = args.extract_figures
+    options.generate_page_images = args.extract_tables
+    options.do_picture_classification = args.extract_figures and args.figure_label_mode == "classification"
+    options.do_picture_description = args.extract_figures and args.figure_label_mode == "description"
+
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(pipeline_options=options),
+        }
+    )
+    result = converter.convert(str(pdf_path))
+    doc = result.document
+
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    if args.extract_figures and artifacts_dir.exists():
+        shutil.rmtree(artifacts_dir)
+    if args.extract_tables and tables_dir.exists():
+        shutil.rmtree(tables_dir)
+    image_mode = ImageRefMode.REFERENCED if args.extract_figures else ImageRefMode.PLACEHOLDER
+    doc.save_as_markdown(
+        md_path,
+        artifacts_dir=artifacts_dir if args.extract_figures else None,
+        image_mode=image_mode,
+        include_annotations=args.extract_figures and args.figure_label_mode != "none",
+    )
+
+    renamed_artifacts: list[Path] = []
+    if args.extract_figures:
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        renamed_artifacts = _rename_docling_artifacts(md_path, artifacts_dir, label_prefix="figure")
+        _extract_figures(doc, pdf_path, artifacts_dir, figures_json, renamed_artifacts)
+
+    if args.extract_tables:
+        _extract_tables(doc, tables_dir, tables_json, args.table_cleanup)
+
+    return md_path
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.fast and (args.extract_figures or args.extract_tables):
+        raise SystemExit("--fast cannot be combined with --extract-figures or --extract-tables.")
+
+    _uv_bootstrap(args)
+
+    pdf_path = Path(args.pdf).expanduser().resolve()
+    if not pdf_path.exists():
+        raise SystemExit(f"PDF not found: {pdf_path}")
+
+    stem = pdf_path.stem
+    docling_md = pdf_path.parent / f"{stem}.docling.md"
+    fast_md = pdf_path.parent / f"{stem}.markitdown.md"
+    fallback_txt = pdf_path.parent / f"{stem}.layout.txt"
+    artifacts_dir = pdf_path.parent / f"{stem}.docling_artifacts"
+    figures_json = pdf_path.parent / f"{stem}.figures.json" if args.extract_figures else None
+    tables_dir = pdf_path.parent / f"{stem}.tables" if args.extract_tables else None
+    tables_json = pdf_path.parent / f"{stem}.tables.json" if args.extract_tables else None
+
+    read_artifact = fast_md if args.fast else docling_md
+    sentinels = [read_artifact]
+    if not args.fast and fallback_txt.exists() and not docling_md.exists():
+        sentinels = [fallback_txt]
+    if figures_json is not None:
+        sentinels.append(figures_json)
+    if tables_json is not None:
+        sentinels.append(tables_json)
+
+    engine = "markitdown" if args.fast else "docling"
+    if not args.force and _is_fresh(pdf_path, sentinels):
+        summary = _build_summary(
+            pdf_path=pdf_path,
+            read_artifact=sentinels[0],
+            engine=engine,
+            cached=True,
+            figures_json=figures_json,
+            tables_json=tables_json,
+        )
+        print(json.dumps(summary, indent=2))
+        return 0
+
+    if args.fast:
+        read_artifact = _run_markitdown(pdf_path, fast_md)
+    else:
+        try:
+            read_artifact = _run_docling(
+                args=args,
+                pdf_path=pdf_path,
+                md_path=docling_md,
+                artifacts_dir=artifacts_dir,
+                figures_json=figures_json,
+                tables_dir=tables_dir,
+                tables_json=tables_json,
+            )
+        except Exception as exc:
+            read_artifact = _run_pdftotext(pdf_path, fallback_txt)
+            engine = "pdftotext-fallback"
+            note = (
+                "Degraded extraction quality: Docling failed, so this artifact was created with "
+                "pdftotext -layout instead.\n\n"
+            )
+            read_artifact.write_text(note + read_artifact.read_text(encoding="utf-8"), encoding="utf-8")
+            if figures_json is not None:
+                _json_dump(figures_json, [])
+            if tables_json is not None:
+                _json_dump(tables_json, [])
+            print(f"Docling failed, falling back to pdftotext: {exc}", file=sys.stderr)
+
+    summary = _build_summary(
+        pdf_path=pdf_path,
+        read_artifact=read_artifact,
+        engine=engine,
+        cached=False,
+        figures_json=figures_json,
+        tables_json=tables_json,
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/general/pdf-reading/scripts/table_cleanup.py
+++ b/skills/general/pdf-reading/scripts/table_cleanup.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class TableCleanupReport:
+    repaired_decimal_markers: int = 0
+    repaired_checkmarks: int = 0
+    repaired_misplaced_signs: int = 0
+    tightened_numeric_spacing: int = 0
+    suspicious_merged_tokens: int = 0
+    max_line_length: int = 0
+    max_pipe_count: int = 0
+    verification_required: bool = False
+    reasons: list[str] = field(default_factory=list)
+
+
+def _subn(pattern: str, repl: str, text: str, count_attr: str, report: TableCleanupReport) -> str:
+    updated, count = re.subn(pattern, repl, text)
+    setattr(report, count_attr, getattr(report, count_attr) + count)
+    return updated
+
+
+def _append_reason(report: TableCleanupReport, reason: str) -> None:
+    if reason not in report.reasons:
+        report.reasons.append(reason)
+
+
+def _repair_misplaced_signs(text: str, report: TableCleanupReport) -> str:
+    lines = text.splitlines()
+    for index in range(1, len(lines)):
+        prev_line = lines[index - 1]
+        curr_line = lines[index]
+        if not prev_line.lstrip().startswith("|") or not curr_line.lstrip().startswith("|"):
+            continue
+
+        prev_cells = prev_line.split("|")
+        curr_cells = curr_line.split("|")
+        if len(prev_cells) != len(curr_cells):
+            continue
+
+        updated = False
+        for cell_index in range(2, len(prev_cells) - 1):
+            prev_cell = prev_cells[cell_index]
+            curr_cell = curr_cells[cell_index]
+            if not re.match(r"^\s*\d", prev_cell):
+                continue
+            if not re.match(r"^\s*-\s*\(", curr_cell):
+                continue
+
+            leading = re.match(r"^(\s*)", prev_cell).group(1)
+            prev_cells[cell_index] = f"{leading}-{prev_cell[len(leading):].lstrip()}"
+            curr_cells[cell_index] = re.sub(r"^(\s*)-\s*", r"\1", curr_cell, count=1)
+            report.repaired_misplaced_signs += 1
+            updated = True
+
+        if updated:
+            lines[index - 1] = "|".join(prev_cells)
+            lines[index] = "|".join(curr_cells)
+
+    return "\n".join(lines)
+
+
+def clean_table_markdown(text: str) -> tuple[str, TableCleanupReport]:
+    report = TableCleanupReport()
+    cleaned = text.replace("\u2212", "-")
+
+    decimal_patterns = (
+        r"(?<=\d)\s*/periodori\s*(?=\d)",
+        r"(?<=\()\s*/periodori\s*(?=\d)",
+        r"(?<=\d)\s*\(cid:4\)\s*(?=\d)",
+        r"(?<=\()\s*\(cid:4\)\s*(?=\d)",
+        r"(?<=\d)\s*\x04\s*(?=\d)",
+        r"(?<=\()\s*\x04\s*(?=\d)",
+    )
+    for pattern in decimal_patterns:
+        cleaned = _subn(pattern, ".", cleaned, "repaired_decimal_markers", report)
+
+    cleaned = _subn(r"\s*/check\b", " checkmark", cleaned, "repaired_checkmarks", report)
+
+    spacing_patterns = (
+        (r"(?<!\w)-\s+(?=\d)", "-"),
+        (r"\(\s+(?=[-0-9])", "("),
+        (r"(?<=\d)\s+\)", ")"),
+        (r"(?<=\d)\s*\.\s*(?=\d)", "."),
+    )
+    for pattern, repl in spacing_patterns:
+        cleaned = _subn(pattern, repl, cleaned, "tightened_numeric_spacing", report)
+
+    cleaned = _repair_misplaced_signs(cleaned, report)
+
+    merged_tokens = re.findall(r"\b[A-Za-z]{20,}\b", cleaned)
+    report.suspicious_merged_tokens = len(merged_tokens)
+    report.max_line_length = max((len(line) for line in cleaned.splitlines()), default=0)
+    report.max_pipe_count = max((line.count("|") for line in cleaned.splitlines()), default=0)
+
+    if report.repaired_decimal_markers >= 4:
+        _append_reason(report, "repaired many corrupted decimal markers")
+    if report.repaired_checkmarks > 0:
+        _append_reason(report, "repaired checkmark placeholders")
+    if report.repaired_misplaced_signs > 0:
+        _append_reason(report, "repaired misplaced negative signs")
+    if report.max_line_length > 240:
+        _append_reason(report, "contains very wide rows")
+    if report.max_pipe_count > 6:
+        _append_reason(report, "contains many columns")
+    if re.search(r"\bPANEL\s+[A-Z]\b", cleaned):
+        _append_reason(report, "contains multi-panel headers")
+    if report.suspicious_merged_tokens > 0:
+        _append_reason(report, "contains merged-text artifacts")
+    if re.search(r"\b2SLS\b|\bR-squared\b|\bObservations\b", cleaned, flags=re.IGNORECASE):
+        _append_reason(report, "looks like a dense academic regression table")
+
+    report.verification_required = bool(report.reasons)
+    return cleaned, report
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Clean Docling table markdown for readability.")
+    parser.add_argument("input", help="Path to the raw table markdown file.")
+    parser.add_argument("-o", "--output", help="Path to write the cleaned markdown.")
+    parser.add_argument("--report", help="Optional JSON report output path.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    text = input_path.read_text(encoding="utf-8")
+    cleaned, report = clean_table_markdown(text)
+
+    if args.output:
+        Path(args.output).expanduser().resolve().write_text(cleaned, encoding="utf-8")
+    else:
+        print(cleaned)
+
+    if args.report:
+        Path(args.report).expanduser().resolve().write_text(
+            json.dumps(asdict(report), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a new `pdf-reading` skill under `skills/general/`
- implement a Docling-first PDF extractor with optional figure and table artifacts
- add table cleanup heuristics for corrupted decimal/checkmark glyphs and verification flags for dense academic tables
- update the root README catalog and install example to include `pdf-reading`

## Details
- `pdf_extract.py` supports Docling reading, figure extraction, table extraction, cache checks, MarkItDown fast mode, and `pdftotext -layout` fallback
- figure extraction writes image artifacts plus `figures.json`
- table extraction writes raw and cleaned Markdown, CSV, crop images, and `tables.json`
- `table_cleanup.py` repairs common PDF glyph issues such as `/periodori`, `(cid:4)`, misplaced negative signs, and checkmark placeholders

## Verification
- compiled the new Python scripts successfully
- exercised the extractor against:
  - an OCR-only sample PDF
  - an image-heavy sample PDF with figure extraction and description mode
  - the CLIP paper in `--fast` MarkItDown mode
  - the MIT wage inequality paper with figures and tables enabled
- confirmed cache hits on repeat runs
