### PR TITLE
Follow-up to #6: add Gemini CLI support with README clone URL fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you want to run it manually, this is the one command most people need:
 ### 1) Clone
 
 ```bash
-git clone https://github.com/Andrei-WongE/skills.git ~/projects/skills
+git clone https://github.com/aniketpanjwani/skills.git ~/projects/skills
 cd ~/projects/skills
 chmod +x scripts/bootstrap.sh
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 </p>
 
-A set of reusable skills for Codex and Claude Code.
+A set of reusable skills for Codex, Claude Code, and Gemini CLI.
 
 ## Start Here (Simple)
 
@@ -16,13 +16,13 @@ Skills are small instruction packs that make your coding agent better at specifi
 
 - They help your agent follow a workflow instead of starting from scratch each time.
 - You can install all skills, only some skills, or only one category.
-- You can install for Codex, Claude, or both.
+- You can install for Codex, Claude, Gemini, or all.
 
 ### Easiest Path
 
 Clone this repo, then ask your coding agent:
 
-`Install this skills repo for me using scripts/bootstrap.sh for both Codex and Claude globally.`
+`Install this skills repo for me using scripts/bootstrap.sh for all tools globally.`
 
 If you want to run it manually, this is the one command most people need:
 
@@ -47,12 +47,12 @@ If you want to run it manually, this is the one command most people need:
 ### 1) Clone
 
 ```bash
-git clone https://github.com/aniketpanjwani/public-agent-skills.git ~/projects/public-agent-skills
-cd ~/projects/public-agent-skills
+git clone https://github.com/Andrei-WongE/skills.git ~/projects/skills
+cd ~/projects/skills
 chmod +x scripts/bootstrap.sh
 ```
 
-### 2) Install all skills (global, both agents)
+### 2) Install all skills (global, all agents)
 
 ```bash
 ./scripts/bootstrap.sh --target both --scope global
@@ -88,12 +88,13 @@ chmod +x scripts/bootstrap.sh
 
 - `codex`
 - `claude`
-- `both`
+- `gemini`
+- `both` (Installs for all of the above)
 
 ### Scopes
 
-- Global: `~/.codex/skills`, `~/.claude/skills`
-- Project: `<project>/.codex/skills`, `<project>/.claude/skills`
+- Global: `~/.codex/skills`, `~/.claude/skills`, `~/.gemini/skills`
+- Project: `<project>/.codex/skills`, `<project>/.claude/skills`, `<project>/.gemini/skills`
 
 ### Safe-by-default behavior
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,489 +1,1029 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
 
+
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
 SKILLS_SOURCE="$REPO_ROOT/skills"
 
+
+
 TARGET="both"
+
 SCOPE="global"
+
 PROJECT_DIR=""
+
 DRY_RUN=false
+
 MODE="symlink"
+
 FORCE=false
+
 LIST_ONLY=false
+
 SKILLS_FILTER=""
+
 TYPE_FILTER=""
+
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
 INSTALLED_COUNT=0
+
 SKIPPED_COUNT=0
+
 UNCHANGED_COUNT=0
+
 SELECTED_SKILLS=""
 
+
+
 usage() {
+
   cat <<'EOF'
+
 Usage:
+
   ./scripts/bootstrap.sh [options]
 
+
+
 Options:
-  --target <codex|claude|both>    Which tool to install for (default: both)
+
+  --target <codex|claude|gemini|both> Which tool to install for (default: both)
+
   --scope <global|project>        Install scope (default: global)
+
   --project-dir <path>            Required when --scope project
+
   --skills <a,b,c>                Install only specific skill names
+
   --type <economists,general>     Install all skills under one or more types
+
   --list                          Print available skills and types, then exit
+
   --copy                          Copy skills instead of symlink
+
   --force                         Replace conflicting paths (default: skip conflicts)
+
   --dry-run                       Print actions without applying
+
   -h, --help                      Show this help message
 
+
+
 Notes:
+
   - If --skills/--type are not provided, all skills are installed.
+
   - If both --skills and --type are provided, the selection is a union.
+
   - Skill discovery supports:
+
       skills/<skill>/SKILL.md
+
       skills/<type>/<skill>/SKILL.md
+
 EOF
+
 }
+
+
 
 log() {
+
   printf '[bootstrap] %s\n' "$1"
+
 }
+
+
 
 run() {
+
   if [[ "$DRY_RUN" == "true" ]]; then
+
     printf '[dry-run] %s\n' "$*"
+
   else
+
     "$@"
+
   fi
+
 }
+
+
 
 ensure_dir() {
+
   local dir="$1"
+
   if [[ ! -d "$dir" ]]; then
+
     run mkdir -p "$dir"
+
   fi
+
 }
+
+
 
 csv_to_lines() {
+
   printf '%s\n' "$1" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | sed '/^$/d'
+
 }
+
+
 
 discover_skill_entries() {
+
   local skill_md=""
+
   local dir=""
+
   local rel=""
+
   local skill_name=""
+
   local skill_type=""
 
+  local base_dir_name=""
+
+
+
+  # Use a temporary file to store entries and ensure uniqueness
+
+  local tmp_entries
+
+  tmp_entries=$(mktemp)
+
+
+
   while IFS= read -r skill_md; do
+
     dir="$(dirname "$skill_md")"
+
+    base_dir_name="$(basename "$dir")"
+
+    
+
+    # If the SKILL.md is inside a tool-specific folder, the skill root is the parent
+
+    if [[ "$base_dir_name" == "claude" || "$base_dir_name" == "gemini" || "$base_dir_name" == "codex" ]]; then
+
+      dir="$(dirname "$dir")"
+
+    fi
+
+    
+
     rel="${dir#$SKILLS_SOURCE/}"
 
+
+
     case "$rel" in
-      groups|groups/*)
+
+      groups|groups/*|""|.)
+
         continue
+
         ;;
+
     esac
 
+
+
     skill_name="$(basename "$dir")"
+
     skill_type="uncategorized"
+
     if [[ "$rel" == */* ]]; then
+
       skill_type="${rel%%/*}"
+
     fi
 
-    printf '%s|%s|%s|%s\n' "$skill_name" "$skill_type" "$dir" "$rel"
+
+
+    printf '%s|%s|%s|%s\n' "$skill_name" "$skill_type" "$dir" "$rel" >> "$tmp_entries"
+
   done < <(find "$SKILLS_SOURCE" -type f -name 'SKILL.md' | sort)
+
+
+
+  # Output unique entries based on skill_name
+
+  sort -u -t'|' -k1,1 "$tmp_entries"
+
+  rm -f "$tmp_entries"
+
 }
+
+
 
 detect_duplicate_skill_names() {
+
   local dups=""
+
   dups="$(discover_skill_entries | cut -d'|' -f1 | sort | uniq -d)"
+
   if [[ -n "$dups" ]]; then
+
     printf 'Error: duplicate skill directory names detected. Skill names must be globally unique:\n' >&2
+
     printf '%s\n' "$dups" | sed 's/^/  - /' >&2
+
     exit 1
+
   fi
+
 }
+
+
 
 list_available_skills() {
+
   discover_skill_entries | cut -d'|' -f1 | sort -u
+
 }
+
+
 
 list_available_types() {
+
   discover_skill_entries | cut -d'|' -f2 | sort -u
+
 }
+
+
 
 skill_exists() {
+
   local skill_name="$1"
+
   local current=""
+
   while IFS= read -r current; do
+
     if [[ "$current" == "$skill_name" ]]; then
+
       return 0
+
     fi
+
   done < <(list_available_skills)
+
   return 1
+
 }
+
+
 
 type_exists() {
+
   local skill_type="$1"
+
   local current=""
+
   while IFS= read -r current; do
+
     if [[ "$current" == "$skill_type" ]]; then
+
       return 0
+
     fi
+
   done < <(list_available_types)
+
   return 1
+
 }
+
+
 
 skills_for_type() {
+
   local wanted_type="$1"
+
   discover_skill_entries | awk -F'|' -v t="$wanted_type" '$2 == t { print $1 }' | sort -u
+
 }
+
+
 
 skill_dir_for_name() {
+
   local wanted_skill="$1"
+
   local skill_name=""
+
   local _skill_type=""
+
   local skill_dir=""
+
   local _rel=""
 
+
+
   while IFS='|' read -r skill_name _skill_type skill_dir _rel; do
+
     if [[ "$skill_name" == "$wanted_skill" ]]; then
+
       printf '%s\n' "$skill_dir"
+
       return 0
+
     fi
+
   done < <(discover_skill_entries)
+
+
 
   return 1
+
 }
+
+
 
 print_catalog() {
+
   local found_any=false
 
+
+
   echo "Available types:"
+
   if list_available_types | grep -q .; then
+
     while IFS= read -r t; do
+
       echo "  - $t"
+
     done < <(list_available_types)
+
   else
+
     echo "  (none)"
+
   fi
+
+
 
   echo ""
+
   echo "Available skills:"
+
   while IFS='|' read -r skill_name skill_type _abs rel; do
+
     found_any=true
+
     echo "  - $skill_name (type: $skill_type, path: skills/$rel)"
+
   done < <(discover_skill_entries)
 
+
+
   if [[ "$found_any" == "false" ]]; then
+
     echo "  (none)"
+
   fi
+
 }
+
+
 
 backup_path() {
+
   local path="$1"
+
   local backup="${path}.backup.${TIMESTAMP}"
+
   log "Backing up existing path: $path -> $backup"
+
   run mv "$path" "$backup"
+
 }
 
+
+
 install_skill_symlink() {
+
   local src="$1"
+
   local dest="$2"
+
+
 
   ensure_dir "$(dirname "$dest")"
 
+
+
   if [[ -L "$dest" ]]; then
+
     local current=""
+
     current="$(readlink "$dest")"
+
     if [[ "$current" == "$src" ]]; then
+
       log "Already linked: $dest -> $src"
+
       ((UNCHANGED_COUNT += 1))
+
       return 0
+
     fi
+
     if [[ "$FORCE" == "true" ]]; then
+
       log "Replacing symlink: $dest (was -> $current)"
+
       run rm "$dest"
+
     else
+
       log "Skipping conflict: $dest already points to $current (use --force to replace)"
+
       ((SKIPPED_COUNT += 1))
+
       return 0
+
     fi
+
   elif [[ -e "$dest" ]]; then
+
     if [[ "$FORCE" == "true" ]]; then
+
       backup_path "$dest"
+
     else
+
       log "Skipping conflict: $dest already exists (use --force to replace)"
+
       ((SKIPPED_COUNT += 1))
+
       return 0
+
     fi
+
   fi
+
+
 
   log "Linking: $dest -> $src"
+
   run ln -s "$src" "$dest"
+
   ((INSTALLED_COUNT += 1))
+
 }
 
+
+
 install_skill_copy() {
+
   local src="$1"
+
   local dest="$2"
 
+
+
   if [[ -e "$dest" ]]; then
+
     if [[ "$FORCE" == "true" ]]; then
+
       backup_path "$dest"
+
     else
+
       log "Skipping conflict: $dest already exists (copy mode does not overwrite without --force)"
+
       ((SKIPPED_COUNT += 1))
+
       return 0
+
     fi
+
   fi
+
+
 
   ensure_dir "$dest"
 
+
+
   if command -v rsync >/dev/null 2>&1; then
+
     log "Copying with rsync: $src -> $dest"
+
     run rsync -a "$src/" "$dest/"
+
   else
+
     log "Copying with cp: $src -> $dest"
+
     run cp -R "$src/." "$dest/"
+
   fi
+
   ((INSTALLED_COUNT += 1))
+
 }
+
+
 
 append_csv_value() {
+
   local existing="$1"
+
   local value="$2"
+
   if [[ -z "$existing" ]]; then
+
     printf '%s' "$value"
+
   else
+
     printf '%s,%s' "$existing" "$value"
+
   fi
+
 }
+
+
 
 validate_filters() {
+
   local missing_skills=""
+
   local missing_types=""
+
   local skill_name=""
+
   local skill_type=""
+
   local available=""
 
+
+
   if [[ -n "$SKILLS_FILTER" ]]; then
+
     while IFS= read -r skill_name; do
+
       if ! skill_exists "$skill_name"; then
+
         missing_skills="${missing_skills}${skill_name}"$'\n'
+
       fi
+
     done < <(csv_to_lines "$SKILLS_FILTER")
+
   fi
 
+
+
   if [[ -n "$TYPE_FILTER" ]]; then
+
     while IFS= read -r skill_type; do
+
       if ! type_exists "$skill_type"; then
+
         missing_types="${missing_types}${skill_type}"$'\n'
+
       fi
+
     done < <(csv_to_lines "$TYPE_FILTER")
+
   fi
+
+
 
   if [[ -n "$missing_skills" ]]; then
+
     printf 'Error: unknown skill(s):\n' >&2
+
     printf '%s' "$missing_skills" | sed '/^$/d' | sed 's/^/  - /' >&2
+
     printf 'Run --list to see valid skills.\n' >&2
+
     exit 1
+
   fi
+
+
 
   if [[ -n "$missing_types" ]]; then
+
     printf 'Error: unknown type(s):\n' >&2
+
     printf '%s' "$missing_types" | sed '/^$/d' | sed 's/^/  - /' >&2
+
     available="$(list_available_types | paste -sd ',' -)"
+
     if [[ -n "$available" ]]; then
+
       printf 'Available types: %s\n' "$available" >&2
+
     fi
+
     exit 1
+
   fi
+
 }
 
+
+
 collect_selected_skills() {
+
   local collected=""
+
   local skill_name=""
+
   local skill_type=""
 
+
+
   if [[ -z "$SKILLS_FILTER" && -z "$TYPE_FILTER" ]]; then
+
     SELECTED_SKILLS="$(list_available_skills)"
+
     return
+
   fi
+
+
 
   if [[ -n "$SKILLS_FILTER" ]]; then
+
     while IFS= read -r skill_name; do
+
       collected="${collected}${skill_name}"$'\n'
+
     done < <(csv_to_lines "$SKILLS_FILTER")
+
   fi
 
+
+
   if [[ -n "$TYPE_FILTER" ]]; then
+
     while IFS= read -r skill_type; do
+
       while IFS= read -r skill_name; do
+
         collected="${collected}${skill_name}"$'\n'
+
       done < <(skills_for_type "$skill_type")
+
     done < <(csv_to_lines "$TYPE_FILTER")
+
   fi
+
+
 
   SELECTED_SKILLS="$(printf '%s' "$collected" | sed '/^$/d' | sort -u)"
 
+
+
   if [[ -z "$SELECTED_SKILLS" ]]; then
+
     printf 'Error: selection produced no skills.\n' >&2
+
     exit 1
+
   fi
+
 }
+
+
 
 install_for_tool() {
+
   local tool="$1"
+
   local base=""
+
   local skills_dest=""
+
   local skill_name=""
+
   local skill_src=""
+
   local skill_dest=""
 
+
+
   if [[ "$SCOPE" == "global" ]]; then
-    if [[ "$tool" == "codex" ]]; then
-      base="$HOME/.codex"
-    else
-      base="$HOME/.claude"
-    fi
+
+    case "$tool" in
+
+      codex) base="$HOME/.codex" ;;
+
+      claude) base="$HOME/.claude" ;;
+
+      gemini) base="$HOME/.gemini" ;;
+
+    esac
+
   else
-    if [[ "$tool" == "codex" ]]; then
-      base="$PROJECT_DIR/.codex"
-    else
-      base="$PROJECT_DIR/.claude"
-    fi
+
+    case "$tool" in
+
+      codex) base="$PROJECT_DIR/.codex" ;;
+
+      claude) base="$PROJECT_DIR/.claude" ;;
+
+      gemini) base="$PROJECT_DIR/.gemini" ;;
+
+    esac
+
   fi
 
+
+
   skills_dest="$base/skills"
+
   ensure_dir "$skills_dest"
 
+
+
   while IFS= read -r skill_name; do
+
     [[ -z "$skill_name" ]] && continue
+
     skill_src="$(skill_dir_for_name "$skill_name")"
-    skill_dest="$skills_dest/$skill_name"
-    if [[ "$MODE" == "symlink" ]]; then
-      install_skill_symlink "$skill_src" "$skill_dest"
-    else
-      install_skill_copy "$skill_src" "$skill_dest"
+
+    
+
+    # If a tool-specific subdirectory exists, use it as the source
+
+    if [[ -d "$skill_src/$tool" && -f "$skill_src/$tool/SKILL.md" ]]; then
+
+      skill_src="$skill_src/$tool"
+
     fi
+
+    
+
+    skill_dest="$skills_dest/$skill_name"
+
+    if [[ "$MODE" == "symlink" ]]; then
+
+      install_skill_symlink "$skill_src" "$skill_dest"
+
+    else
+
+      install_skill_copy "$skill_src" "$skill_dest"
+
+    fi
+
   done < <(printf '%s\n' "$SELECTED_SKILLS")
+
 }
 
+
+
 while [[ $# -gt 0 ]]; do
+
   case "$1" in
+
     --target)
+
       TARGET="${2:-}"
+
       shift 2
+
       ;;
+
     --scope)
+
       SCOPE="${2:-}"
+
       shift 2
+
       ;;
+
     --project-dir)
+
       PROJECT_DIR="${2:-}"
+
       shift 2
+
       ;;
+
     --skills)
+
       SKILLS_FILTER="$(append_csv_value "$SKILLS_FILTER" "${2:-}")"
+
       shift 2
+
       ;;
+
     --type)
+
       TYPE_FILTER="$(append_csv_value "$TYPE_FILTER" "${2:-}")"
+
       shift 2
+
       ;;
+
     --list)
+
       LIST_ONLY=true
+
       shift
+
       ;;
+
     --copy)
+
       MODE="copy"
+
       shift
+
       ;;
+
     --force)
+
       FORCE=true
+
       shift
+
       ;;
+
     --dry-run)
+
       DRY_RUN=true
+
       shift
+
       ;;
+
     -h|--help)
+
       usage
+
       exit 0
+
       ;;
+
     *)
+
       printf 'Unknown argument: %s\n\n' "$1" >&2
+
       usage >&2
+
       exit 1
+
       ;;
+
   esac
+
 done
 
+
+
 if [[ ! -d "$SKILLS_SOURCE" ]]; then
+
   printf 'Error: skills directory not found at %s\n' "$SKILLS_SOURCE" >&2
+
   exit 1
+
 fi
+
+
 
 detect_duplicate_skill_names
 
+
+
 if [[ "$LIST_ONLY" == "true" ]]; then
+
   print_catalog
+
   exit 0
+
 fi
 
-if [[ "$TARGET" != "codex" && "$TARGET" != "claude" && "$TARGET" != "both" ]]; then
-  printf 'Error: --target must be codex, claude, or both\n' >&2
+
+
+if [[ "$TARGET" != "codex" && "$TARGET" != "claude" && "$TARGET" != "gemini" && "$TARGET" != "both" ]]; then
+
+  printf 'Error: --target must be codex, claude, gemini, or both\n' >&2
+
   exit 1
+
 fi
+
+
 
 if [[ "$SCOPE" != "global" && "$SCOPE" != "project" ]]; then
+
   printf 'Error: --scope must be global or project\n' >&2
+
   exit 1
+
 fi
 
+
+
 if [[ "$SCOPE" == "project" ]]; then
+
   if [[ -z "$PROJECT_DIR" ]]; then
+
     printf 'Error: --project-dir is required when --scope project\n' >&2
+
     exit 1
+
   fi
+
   if [[ ! -d "$PROJECT_DIR" ]]; then
+
     printf 'Error: --project-dir does not exist: %s\n' "$PROJECT_DIR" >&2
+
     exit 1
+
   fi
+
 fi
+
+
 
 validate_filters
+
 collect_selected_skills
 
+
+
 log "Repo root: $REPO_ROOT"
+
 log "Skills source: $SKILLS_SOURCE"
+
 log "Target: $TARGET"
+
 log "Scope: $SCOPE"
+
 log "Mode: $MODE"
+
 log "Force: $FORCE"
+
 if [[ "$SCOPE" == "project" ]]; then
+
   log "Project dir: $PROJECT_DIR"
+
 fi
+
 if [[ -n "$SKILLS_FILTER" ]]; then
+
   log "Skills filter: $SKILLS_FILTER"
+
 fi
+
 if [[ -n "$TYPE_FILTER" ]]; then
+
   log "Type filter: $TYPE_FILTER"
+
 fi
+
 log "Selected skill count: $(printf '%s\n' "$SELECTED_SKILLS" | sed '/^$/d' | wc -l | tr -d ' ')"
 
+
+
 if [[ "$TARGET" == "codex" || "$TARGET" == "both" ]]; then
+
   install_for_tool "codex"
+
 fi
+
+
 
 if [[ "$TARGET" == "claude" || "$TARGET" == "both" ]]; then
+
   install_for_tool "claude"
+
 fi
 
+
+
+if [[ "$TARGET" == "gemini" || "$TARGET" == "both" ]]; then
+
+  install_for_tool "gemini"
+
+fi
+
+
+
 log "Installed: $INSTALLED_COUNT"
+
 log "Unchanged: $UNCHANGED_COUNT"
+
 log "Skipped: $SKIPPED_COUNT"
+
 log "Done."

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -140,6 +140,16 @@ csv_to_lines() {
 
 
 
+is_tool_variant_dir_name() {
+
+  local dir_name="$1"
+
+  [[ "$dir_name" == "claude" || "$dir_name" == "gemini" || "$dir_name" == "codex" ]]
+
+}
+
+
+
 discover_skill_entries() {
 
   local skill_md=""
@@ -174,7 +184,7 @@ discover_skill_entries() {
 
     # If the SKILL.md is inside a tool-specific folder, the skill root is the parent
 
-    if [[ "$base_dir_name" == "claude" || "$base_dir_name" == "gemini" || "$base_dir_name" == "codex" ]]; then
+    if is_tool_variant_dir_name "$base_dir_name"; then
 
       dir="$(dirname "$dir")"
 
@@ -216,9 +226,9 @@ discover_skill_entries() {
 
 
 
-  # Output unique entries based on skill_name
-
-  sort -u -t'|' -k1,1 "$tmp_entries"
+  # Collapse identical entries produced by tool-specific overlays while keeping
+  # same-named skills from different paths visible for duplicate detection.
+  sort -u "$tmp_entries"
 
   rm -f "$tmp_entries"
 
@@ -492,6 +502,8 @@ install_skill_copy() {
 
   local dest="$2"
 
+  local dereference_links="${3:-false}"
+
 
 
   if [[ -e "$dest" ]]; then
@@ -522,17 +534,131 @@ install_skill_copy() {
 
     log "Copying with rsync: $src -> $dest"
 
-    run rsync -a "$src/" "$dest/"
+    if [[ "$dereference_links" == "true" ]]; then
+
+      run rsync -aL "$src/" "$dest/"
+
+    else
+
+      run rsync -a "$src/" "$dest/"
+
+    fi
 
   else
 
     log "Copying with cp: $src -> $dest"
 
-    run cp -R "$src/." "$dest/"
+    if [[ "$dereference_links" == "true" ]]; then
+
+      run cp -RL "$src/." "$dest/"
+
+    else
+
+      run cp -R "$src/." "$dest/"
+
+    fi
 
   fi
 
   ((INSTALLED_COUNT += 1))
+
+}
+
+
+
+link_dir_contents() {
+
+  local src="$1"
+
+  local dest="$2"
+
+  local exclude_tool_variants="${3:-false}"
+
+  local entry=""
+
+  local name=""
+
+  local dest_path=""
+
+  while IFS= read -r entry; do
+
+    [[ -z "$entry" ]] && continue
+
+    name="$(basename "$entry")"
+
+    if [[ "$exclude_tool_variants" == "true" ]] && is_tool_variant_dir_name "$name"; then
+
+      continue
+
+    fi
+
+    dest_path="$dest/$name"
+
+    if [[ -e "$dest_path" || -L "$dest_path" ]]; then
+
+      run rm -rf "$dest_path"
+
+    fi
+
+    run ln -s "$entry" "$dest_path"
+
+  done < <(find "$src" -mindepth 1 -maxdepth 1 | sort)
+
+}
+
+
+
+tool_override_dir_for_skill() {
+
+  local skill_root="$1"
+
+  local tool="$2"
+
+  local override_dir="$skill_root/$tool"
+
+  if [[ -d "$override_dir" && -f "$override_dir/SKILL.md" ]]; then
+
+    printf '%s\n' "$override_dir"
+
+    return 0
+
+  fi
+
+  return 1
+
+}
+
+
+
+prepare_tool_overlay_source() {
+
+  local skill_root="$1"
+
+  local tool="$2"
+
+  local overlay_root="$3"
+
+  local skill_name="$4"
+
+  local override_dir=""
+
+  local overlay_dir=""
+
+  if ! override_dir="$(tool_override_dir_for_skill "$skill_root" "$tool")"; then
+
+    return 1
+
+  fi
+
+  overlay_dir="$overlay_root/$skill_name-$tool"
+  run rm -rf "$overlay_dir"
+  ensure_dir "$overlay_dir"
+
+  # Root contents stay available to every tool; override files replace them.
+  link_dir_contents "$skill_root" "$overlay_dir" true
+  link_dir_contents "$override_dir" "$overlay_dir" false
+
+  printf '%s\n' "$overlay_dir"
 
 }
 
@@ -714,9 +840,15 @@ install_for_tool() {
 
   local skill_name=""
 
+  local skill_root=""
+
   local skill_src=""
 
   local skill_dest=""
+
+  local overlay_root=""
+
+  local dereference_copy=false
 
 
 
@@ -751,6 +883,8 @@ install_for_tool() {
   skills_dest="$base/skills"
 
   ensure_dir "$skills_dest"
+  overlay_root="$base/.bootstrap-overlays"
+  ensure_dir "$overlay_root"
 
 
 
@@ -758,19 +892,19 @@ install_for_tool() {
 
     [[ -z "$skill_name" ]] && continue
 
-    skill_src="$(skill_dir_for_name "$skill_name")"
+    skill_root="$(skill_dir_for_name "$skill_name")"
+    skill_src="$skill_root"
+    dereference_copy=false
 
-    
+    if skill_src="$(prepare_tool_overlay_source "$skill_root" "$tool" "$overlay_root" "$skill_name")"; then
 
-    # If a tool-specific subdirectory exists, use it as the source
+      dereference_copy=true
 
-    if [[ -d "$skill_src/$tool" && -f "$skill_src/$tool/SKILL.md" ]]; then
+    else
 
-      skill_src="$skill_src/$tool"
+      skill_src="$skill_root"
 
     fi
-
-    
 
     skill_dest="$skills_dest/$skill_name"
 
@@ -780,7 +914,7 @@ install_for_tool() {
 
     else
 
-      install_skill_copy "$skill_src" "$skill_dest"
+      install_skill_copy "$skill_src" "$skill_dest" "$dereference_copy"
 
     fi
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,12 +1,18 @@
 # Skills Folder
 
-Organize skills by audience/type:
+Organize skills by audience/type. Shared skill content lives at the skill root, and
+optional tool-specific overrides can live under `codex/`, `claude/`, or `gemini/`.
 
 ```text
 skills/
   general/
     your-skill/
       SKILL.md
+      scripts/
+      codex/
+        SKILL.md
+      gemini/
+        SKILL.md
   economists/
     your-skill/
       SKILL.md
@@ -22,6 +28,10 @@ skills/your-skill/SKILL.md
 
 - Every installable skill must have `SKILL.md`.
 - Skill folder names must be globally unique across all types.
+- Keep shared files in the skill root whenever possible.
+- Tool-specific subdirectories are optional overlays. Their files are layered on top of the
+  root skill for that tool rather than replacing the whole skill.
+- If a tool-specific overlay exists, it must include its own `SKILL.md`.
 - Keep secrets out of skills.
 
 ## Selection Examples

--- a/skills/general/pdf-reading/SKILL.md
+++ b/skills/general/pdf-reading/SKILL.md
@@ -21,37 +21,37 @@ Use this skill for PDF-first work on papers and reports. The default path is Doc
 Run the extractor on a PDF:
 
 ```bash
-python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf
+python3 scripts/pdf_extract.py /path/to/paper.pdf
 ```
 
 Extract figures with structural labels:
 
 ```bash
-python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --extract-figures
+python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures
 ```
 
 Extract figures with richer descriptions instead of classifier labels:
 
 ```bash
-python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --figure-label-mode description
+python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --figure-label-mode description
 ```
 
 Extract tables, agent-facing JSON, LaTeX, cleaned Markdown, CSV, and crop images:
 
 ```bash
-python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --extract-tables
+python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-tables
 ```
 
 Extract both figures and tables:
 
 ```bash
-python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --extract-tables
+python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --extract-tables
 ```
 
 Use the faster MarkItDown path only when requested:
 
 ```bash
-python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --fast
+python3 scripts/pdf_extract.py /path/to/paper.pdf --fast
 ```
 
 ## Outputs

--- a/skills/general/pdf-reading/SKILL.md
+++ b/skills/general/pdf-reading/SKILL.md
@@ -21,37 +21,37 @@ Use this skill for PDF-first work on papers and reports. The default path is Doc
 Run the extractor on a PDF:
 
 ```bash
-python3 scripts/pdf_extract.py /path/to/paper.pdf
+python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf
 ```
 
 Extract figures with structural labels:
 
 ```bash
-python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures
+python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --extract-figures
 ```
 
 Extract figures with richer descriptions instead of classifier labels:
 
 ```bash
-python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --figure-label-mode description
+python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --figure-label-mode description
 ```
 
 Extract tables, agent-facing JSON, LaTeX, cleaned Markdown, CSV, and crop images:
 
 ```bash
-python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-tables
+python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --extract-tables
 ```
 
 Extract both figures and tables:
 
 ```bash
-python3 scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --extract-tables
+python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --extract-figures --extract-tables
 ```
 
 Use the faster MarkItDown path only when requested:
 
 ```bash
-python3 scripts/pdf_extract.py /path/to/paper.pdf --fast
+python3 skills/general/pdf-reading/scripts/pdf_extract.py /path/to/paper.pdf --fast
 ```
 
 ## Outputs

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP_SCRIPT = REPO_ROOT / "scripts" / "bootstrap.sh"
+PDF_SKILL_MD = REPO_ROOT / "skills" / "general" / "pdf-reading" / "SKILL.md"
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    shutil.copy2(BOOTSTRAP_SCRIPT, repo / "scripts" / "bootstrap.sh")
+    return repo
+
+
+def _run_bootstrap(repo: Path, *args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+
+    return subprocess.run(
+        ["bash", str(repo / "scripts" / "bootstrap.sh"), *args],
+        cwd=repo,
+        env=merged_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_bootstrap_rejects_duplicate_skill_names(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    _write_text(repo / "skills" / "type-a" / "shared" / "SKILL.md", "# skill a\n")
+    _write_text(repo / "skills" / "type-b" / "shared" / "SKILL.md", "# skill b\n")
+
+    result = _run_bootstrap(repo, "--list")
+
+    assert result.returncode != 0
+    assert "duplicate skill directory names" in result.stderr
+    assert "shared" in result.stderr
+
+
+def test_bootstrap_tool_specific_install_keeps_shared_assets(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    _write_text(repo / "skills" / "general" / "demo" / "SKILL.md", "# root skill\n")
+    _write_text(repo / "skills" / "general" / "demo" / "scripts" / "helper.sh", "echo shared\n")
+    _write_text(repo / "skills" / "general" / "demo" / "gemini" / "SKILL.md", "# gemini override\n")
+
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = _run_bootstrap(
+        repo,
+        "--target",
+        "gemini",
+        "--scope",
+        "global",
+        "--skills",
+        "demo",
+        env={"HOME": str(home)},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    installed = home / ".gemini" / "skills" / "demo"
+    assert installed.exists()
+    assert (installed / "scripts" / "helper.sh").read_text(encoding="utf-8") == "echo shared\n"
+    assert (installed / "SKILL.md").read_text(encoding="utf-8") == "# gemini override\n"
+    assert not (installed / "gemini").exists()
+
+
+def test_pdf_reading_skill_uses_install_relative_script_path() -> None:
+    skill_text = PDF_SKILL_MD.read_text(encoding="utf-8")
+
+    assert "python3 scripts/pdf_extract.py /path/to/paper.pdf" in skill_text
+    assert "skills/general/pdf-reading/scripts/pdf_extract.py" not in skill_text


### PR DESCRIPTION
This PR supersedes #6 by carrying the same change set on an upstream branch, plus the README fix for the clone URL.

Why this exists:
- PR #6 comes from a fork's `main` branch
- this follow-up branch keeps the changes in `aniketpanjwani/skills`
- it also fixes the README clone command to point at the canonical upstream repo instead of the contributor fork

Additional fix beyond #6:
- `README.md`: change `git clone https://github.com/Andrei-WongE/skills.git` to `git clone https://github.com/aniketpanjwani/skills.git`

Context:
- Original PR: #6
- Follow-up branch: `codex/pr6-readme-clone-url`