### PR TITLE
Add land skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you want to run it manually, this is the one command most people need:
 | `claude-code-delegate` | Agent workflows | Delegate general Codex tasks to interactive Claude Code with artifact monitoring and question brokering | `skills/agent-workflows/claude-code-delegate` |
 | `claude-pr-review` | Agent workflows | Delegate PR review to Claude Code and Compound Engineering, post GitHub comments, and queue Codex fixes | `skills/agent-workflows/claude-pr-review` |
 | `goal-contract` | Agent workflows | Draft, critique, refine, and activate evidence-checkable agent Goals | `skills/agent-workflows/goal-contract` |
+| `land` | Agent workflows | Finish approved Git work through commits, PR readiness, exact-head merge verification, and local default-branch synchronization | `skills/agent-workflows/land` |
 | `disk-space-advisor` | General | Evidence-first disk cleanup and external-drive archive decisions with a read-only inventory helper | `skills/general/disk-space-advisor` |
 | `oracle` | General | Bundle prompts and selected files with the Oracle CLI for ChatGPT-ready review packages | `skills/general/oracle` |
 | `pdf-reading` | General | Docling-first PDF reading with optional figure, image, and table extraction artifacts | `skills/general/pdf-reading` |

--- a/skills/agent-workflows/land/SKILL.md
+++ b/skills/agent-workflows/land/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: land
+description: "Finish approved work through the complete GitHub landing lifecycle: inspect the checkout, propose atomic commit groups, create or preserve a feature branch, commit, validate, push, create or reuse a pull request, babysit readiness, merge the exact approved head, verify the result, and return the repository's primary worktree to an updated local default branch. Use when the user asks to land, finish, ship, merge, or cleanly wrap up work in a Git worktree. Do not use for merely updating the repository default branch; use $git-up for that."
+---
+
+# Land
+
+Use `$land` to finish work without making the user restate the branch, atomic-commit, pull-request, readiness, merge, verification, and local-default synchronization sequence.
+
+## Required dependencies
+
+This skill orchestrates, but does not reimplement:
+
+- `$ce-commit-push-pr`
+- `$ce-babysit-pr`
+- `git`
+- authenticated GitHub CLI `gh`
+
+Confirm every dependency before mutation. If one is unavailable, stop with the missing prerequisite and a resume instruction. Do not replace a missing Compound skill with an improvised workflow.
+
+## Contract
+
+- Run the full lifecycle by default. Omit a stage only when the user's invocation explicitly requests that omission.
+- Read [references/landing-protocol.md](references/landing-protocol.md) completely before taking action, then follow it as the authoritative workflow.
+- Inspect first and present one concern-based, file-specific atomic commit proposal before the first branch, staging, commit, push, pull-request, or merge mutation.
+- Treat that one approval as bounded authorization for the approved scope and its later exact-head merge. Do not ask for a routine second merge confirmation.
+- Hard-stop before staging or pushing if a suspected credential or secret is found anywhere in the complete candidate history or a later merge-candidate head. Resume only after the required removal, history remediation, and credential response or false-positive verification; never continue by silently omitting it.
+- Verify that the exact approved head was integrated into the actual base with the selected merge method. Never require the entire integrated tree to equal the pull-request-head tree when the base may contain newer, nonconflicting changes.
+- Preserve unrelated work and every linked or managed worktree. Never delete the feature branch or any worktree.
+- After a verified remote merge, return the repository's primary worktree—the regular checkout recorded by Git—to the local default branch and safely fast-forward it. When the landing checkout is the primary worktree, switch that checkout; when landing from a linked Codex, Claude, or other managed worktree, leave it in place and update the primary worktree separately. Never stash, reset, clean, force-switch, or discard work to make synchronization succeed.
+- Do not interrupt or warn the user merely because a repository intentionally has no hosted CI. When the protocol freshly proves that no GitHub Actions workflows and no required status checks are configured, use successful approved local validation and continue the landing lifecycle silently.
+- Stop on ambiguity, changed scope, failed or unknown readiness gates, unresolved human decisions, or stale head evidence.
+
+## Delegation
+
+After approval:
+
+1. Invoke `$ce-commit-push-pr` through the host's normal skill mechanism with `mode:pipeline babysit:off`. Pass the approved commit groups, existing commits, explicit omissions, and pull-request reuse context as authoritative scope.
+2. Invoke `$ce-babysit-pr` as the sole readiness owner, with `mode:pipeline` and the resulting pull-request URL. Never run a concurrent or substitute watcher.
+3. Resume the landing protocol's fresh exact-head gate. `$ce-babysit-pr` returning ready is evidence to revalidate, not permission to skip revalidation.
+
+The landing protocol's narrow `hosted-CI-not-configured` classification is the only case in which a `no-checks-observed` babysitter residual may advance. It classifies repository capability with fresh read-only evidence; it does not replace the babysitter or reinterpret a configured check.
+
+Do not copy or approximate either Compound skill's internal procedure.
+
+## User interaction
+
+Use the host's blocking question mechanism for the single scope approval when available. Otherwise ask one concise numbered chat question and wait. Any later question must represent a real scope change, safety decision, or external blocker.
+
+Every stopped or completed result must state what completed, what did not, whether mutation occurred, the exact blocker or merge evidence, the landing-worktree state, and the primary-worktree/default-branch synchronization state.

--- a/skills/agent-workflows/land/agents/openai.yaml
+++ b/skills/agent-workflows/land/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Land"
+  short_description: "Safely finish, publish, and merge approved work"
+  default_prompt: "Use $land to propose atomic commit groups, then finish the approved branch, pull request, readiness, verified merge, and primary-worktree default-branch synchronization lifecycle."

--- a/skills/agent-workflows/land/references/landing-protocol.md
+++ b/skills/agent-workflows/land/references/landing-protocol.md
@@ -1,0 +1,214 @@
+# Landing protocol
+
+Read and apply every section for each `$land` run. This protocol owns orchestration, authorization boundaries, terminal merge, and reporting; the invoked Compound Engineering skills own their internal procedures.
+
+## 1. Normalize the request
+
+The default is the full lifecycle:
+
+`inspect -> approve scope -> branch -> atomic commits -> validate -> push -> create or reuse PR -> babysit -> revalidate -> merge -> verify -> synchronize local default -> report`
+
+Only an explicit natural-language instruction may omit a stage. Record every omission in the scope proposal. Silence never means omit. An omission cannot weaken the suspected-secret hard stop, include unapproved work, or permit a stale-head merge.
+
+## 2. Preflight without mutation
+
+Confirm:
+
+- the checkout is a Git repository;
+- its target forge is GitHub;
+- `git`, authenticated `gh`, `$ce-commit-push-pr`, and `$ce-babysit-pr` are available;
+- the repository's default branch, remotes, merge-method settings, primary worktree, and relevant linked worktrees;
+- current branch or detached HEAD, HEAD object ID, upstream and ahead/behind state;
+- staged, unstaged, untracked, ignored, generated, and pre-existing paths;
+- commits not represented by the upstream;
+- a matching open, closed, or merged pull request, if any.
+
+Use read-only commands and APIs. Do not switch or create a branch, stage, commit, push, edit a pull request, or merge during preflight.
+
+Classify the starting state:
+
+1. **Uncommitted work:** group changed files by concern.
+2. **Existing commits:** describe the commits that still need publication or landing.
+3. **Matching open PR:** reuse it; do not create a duplicate.
+4. **Already merged:** verify the remote terminal state, then inspect whether the local default branch still needs synchronization.
+5. **No landing work:** report a no-op.
+
+A true terminal no-op needs no approval because it performs no mutation. An already-merged pull request with a stale local default branch is not a no-op; obtain approval for the local synchronization unless the invocation already authorized the full lifecycle.
+
+## 3. Build the approved scope
+
+Form the smallest independently coherent commit groups. For each group, list:
+
+- exact paths;
+- commit intent and proposed message;
+- validation appropriate to that concern.
+
+Separately list unrelated, generated, sensitive, pre-existing, and ambiguous paths. Do not infer ownership from proximity. Include existing commits and the intended pull-request create/reuse action.
+
+### Suspected-secret hard stop
+
+Before proposing approval, apply any repository-native secret scanner and inspect the complete candidate landing delta for credential material such as private keys, access tokens, passwords, signing material, or committed secret files. The delta includes every existing commit from the merge base or upstream through the candidate head plus staged, unstaged, and intended untracked content. Repeat this check for every new merge-candidate head produced later in the workflow.
+
+Use a scanner's redacted or path-only output mode. If an available scanner cannot avoid displaying candidate values, do not run it in a way that puts raw output in chat or durable logs; use a safe inspection path and report only redacted metadata.
+
+If any signal is positive:
+
+- stop before branch creation, staging, commit, or push;
+- report only the affected path, detector category, and remediation state;
+- do not expose the candidate value;
+- do not offer exclusion of the path as a bypass;
+- for uncommitted material, resume only after it is removed from both the intended scope and checkout, or inspection verifies the signal is a false positive;
+- for material already committed, stop until the branch history is sanitized and the complete candidate landing delta passes again; do not rewrite history automatically;
+- for material already pushed, also require credential revocation or rotation and explicit remote-history remediation before continuing;
+- repeat the full read-only inspection and complete secret check after remediation.
+
+User approval cannot override this hard stop.
+
+## 4. One approval boundary
+
+Present one checkpoint containing:
+
+- the exact commit groups, paths, messages, and validations;
+- existing commits included in the landing scope;
+- every excluded or preserved path;
+- branch action and pull-request create/reuse action;
+- every explicit lifecycle omission;
+- the intended repository-allowed merge method, or how it will be selected;
+- the intended primary-worktree switch and local default-branch synchronization, including how an unsafe primary worktree or conflicting branch owner will be reported;
+- the statement that approval authorizes the approved scope and the later merge of its freshly revalidated exact head.
+
+Ask the user to approve or revise this proposal. Perform no mutation before approval. If the scope changes later, or a remediation would alter intended behavior beyond the approved concern, stop and obtain a revised scope approval.
+
+## 5. Publish the approved work
+
+Invoke `$ce-commit-push-pr` through the active host's skill mechanism with:
+
+`mode:pipeline babysit:off`
+
+Pass the approval record as authoritative caller context: file groups, commit intent, existing commits, exclusions, explicit omissions, branch constraints, and matching pull-request state.
+
+The delegated skill should:
+
+- create a suitable feature branch for a detached or default-branch checkout, while preserving a suitable existing feature branch;
+- create the approved atomic commits without staging excluded paths;
+- run proportionate validation;
+- push the live head exactly;
+- create or reuse the matching pull request.
+
+If the delegate cannot honor the approved grouping, stop. Record the published head object ID and pull-request URL after it returns. Reinspect the checkout to ensure excluded work remains untouched.
+
+For an explicitly omitted later stage, perform every preceding non-omitted stage and stop immediately before the omitted stage. For example, “do not merge” still establishes and freshly revalidates readiness unless the user also omitted readiness work. Report the precise resumable state.
+
+## 6. Establish readiness
+
+Invoke `$ce-babysit-pr` through the host's normal skill mechanism, with the pull-request URL and `mode:pipeline`. It is the sole owner of checks, review feedback, branch currency, and its bounded remediation loop.
+
+Do not start a concurrent watcher, substitute a different readiness owner, or reconstruct the babysitting loop. If the babysitter changes the branch, diff the previous candidate against the new head at path and hunk level, then re-run the suspected-secret hard stop over the new commits and content. Accept the new head only when every change remains within the approved concern and the secret check passes; otherwise stop for remediation or revised scope approval. Capture the resulting live head as the merge candidate.
+
+A ready or looks-ready return advances to fresh revalidation. A residual, failed gate, draft boundary, unresolved human decision, or unknown state blocks merge.
+
+### Repositories without hosted CI
+
+An otherwise-ready `no-checks-observed` result is not a user-facing blocker when hosted CI is intentionally absent. Apply this narrow classification only when all of the following fresh, read-only evidence agrees for the exact merge-candidate head and base branch:
+
+- the babysitter's only residual is an empty check rollup, with no failing, pending, approval-gated, or unknown check;
+- the repository exposes no GitHub Actions workflow through the Actions workflows API and the exact candidate tree contains no `.github/workflows/*.yml` or `.github/workflows/*.yaml` file;
+- branch protection or repository rules require no status-check context for the target branch;
+- the approved local validation completed successfully against the exact merge-candidate head; and
+- every non-check babysitter readiness gate passed.
+
+Record this internally as `hosted-CI-not-configured`, advance directly to exact-head revalidation, and do not interrupt the user or surface the expected absence as a warning. This is capability classification, not a substitute readiness loop: `$ce-babysit-pr` remains the sole owner of review feedback, observed checks, branch currency, and remediation.
+
+If any probe is denied, malformed, stale, or ambiguous, or if any workflow, required context, configured check, or failed local validation exists, the exception does not apply. Preserve the ordinary blocker rather than inferring that CI is absent.
+
+## 7. Revalidate the exact head
+
+Immediately before merge, fetch fresh local and GitHub state. Require all of the following:
+
+- the pull request is open and not draft;
+- its current head object ID equals the approved, published merge-candidate head;
+- the local feature head, pushed remote head, and pull-request head agree;
+- when hosted CI is configured, required checks are present, terminal, and passing; otherwise the fresh classification is `hosted-CI-not-configured` and approved local validation passed against the exact head;
+- review requirements pass and no actionable review thread or feedback remains;
+- GitHub mergeability is certain and clean;
+- the base branch identity and currency are current and known;
+- no stack/dependency blocker or parked human decision remains;
+- the suspected-secret check passed for the current merge-candidate head and every commit/content change since approval;
+- the selected merge method is allowed by both the repository and any explicit user instruction.
+
+Treat missing, empty, stale, changing, or unknown evidence as failure unless the empty check rollup has the complete fresh `hosted-CI-not-configured` evidence above. If the head changes, invalidate that classification and return to inspection for the new head; never merge using evidence from an earlier head. If its scope remains approved, re-invoke `$ce-babysit-pr mode:pipeline` as the same sole readiness owner before revalidation. If scope changed, obtain revised approval first.
+
+Merge-method precedence:
+
+1. explicit user instruction;
+2. repository convention or required method;
+3. an allowed method that preserves approved atomic commits.
+
+If more than one method remains and selection would require guessing, stop. Use the corresponding non-interactive `gh pr merge` method only after every gate above passes.
+
+## 8. Verify the remote merge
+
+Re-read the pull request from GitHub and require:
+
+- terminal state `MERGED`;
+- a recorded merge timestamp and merge commit object ID;
+- the pull request's recorded head object ID equals the exact merge-candidate head;
+- the selected merge method is known;
+- the base object ID used by the final exact-head gate is recorded as the validated base; and
+- after fetching the validated base, approved head, and recorded integration commit, the recorded integration tree equals the tree produced by integrating that approved head into the applicable base with the selected method.
+
+Use the deterministic helper rather than comparing the complete integration tree directly to the pull-request-head tree:
+
+```bash
+python3 skills/land/scripts/verify-remote-merge.py \
+  --repo <repository> \
+  --method <merge|squash|rebase> \
+  --candidate <exact-approved-head> \
+  --validated-base <base-object-from-final-gate> \
+  --integration <recorded-merge-commit>
+```
+
+The helper verifies method-specific structure and computes the expected integration tree with Git's merge machinery without changing a worktree or ref:
+
+- **Merge:** require exactly two parents, require the approved head to be the second parent and an ancestor of the integration commit, use the first parent as the actual integration base, require the validated base to equal or precede that actual base, and compare the recorded tree with the expected merge tree.
+- **Squash:** require exactly one parent, use that parent as the actual integration base, require the validated base to equal or precede that actual base, and compare the recorded tree with the expected merge tree. Do not require approved-head ancestry.
+- **Rebase:** require the validated base to be an ancestor of the recorded terminal integration commit and compare its recorded tree with the expected tree for integrating the approved head into that validated base. Do not require approved-head ancestry because the commits were rewritten. If the base moved after validation or the validated base cannot unambiguously anchor the replay, fail closed and repeat readiness plus exact-head validation before another merge attempt.
+
+This verification deliberately permits newer, nonconflicting base changes for merge and squash: those changes belong in both the actual integration base and the expected integration tree. A direct equality check between the recorded integration tree and the pull-request-head tree is invalid whenever the base advanced independently.
+
+If terminal evidence is missing or mismatched, report the result as unverified and do not claim success.
+
+## 9. Synchronize the primary worktree and local default branch
+
+Only after the remote merge passes Section 8, return the repository's primary worktree to the verified pull request's base branch and synchronize it. The **primary worktree** is Git's regular repository checkout, not whichever linked worktree happens to own the default branch. This stage is part of the full lifecycle, including an already-merged invocation whose remote result is verified but whose primary worktree is on another branch or whose local default branch is stale.
+
+1. Resolve the verified pull request's base branch `<base>` and its corresponding remote `<remote>`. Fetch `<remote>/<base>` without changing any checkout.
+2. Run `git worktree list --porcelain`. Treat its first `worktree` record as the primary-worktree candidate, then positively verify it is the non-bare main checkout by requiring `git -C <primary> rev-parse --is-bare-repository` to return `false` and `git -C <primary> rev-parse --path-format=absolute --git-dir` to equal `git -C <primary> rev-parse --path-format=absolute --git-common-dir`. Do not infer the primary worktree from a human-looking path. If the candidate is missing, inaccessible, bare, or fails this identity check, record `primary-worktree-unresolved` and stop local synchronization.
+3. Inspect every worktree's branch entry. If a worktree other than `<primary>` owns `refs/heads/<base>`, record `default-branch-owned-outside-primary` and stop; do not switch, detach, delete, or otherwise disrupt that worktree to reclaim the branch.
+4. Inspect `<primary>` before mutation. Require:
+   - no merge, rebase, cherry-pick, or revert is in progress;
+   - no staged or unstaged tracked changes;
+   - the local `<base>` branch exists and its current commit is either equal to or an ancestor of the freshly fetched `<remote>/<base>`;
+   - when `<primary>` is also the landing checkout, its checked-out HEAD still equals the verified merge-candidate head and no post-merge work appeared.
+5. Preserve untracked paths exactly as found. Never stash, delete, clean, reset, or overwrite them. A branch switch or fast-forward that would collide with an untracked path must fail closed and leave that path untouched.
+6. If `<primary>` is not already on `<base>`, run `git -C <primary> switch <base>`. This switch is expected when the landing checkout is the primary worktree; from a linked Codex, Claude, or other managed worktree, leave the landing worktree untouched and switch only `<primary>`. Never force the switch.
+7. If the two heads already agree, record a synchronization no-op. Otherwise run `git -C <primary> merge --ff-only <remote>/<base>`. Do not use pull, rebase, a merge commit, or a forced update.
+8. Verify that `<primary>` is on `<base>` and its HEAD equals `<remote>/<base>`. Record the primary path, whether it was also the landing checkout, its prior branch and old HEAD, its new branch and HEAD, the remote HEAD, ahead/behind counts, and staged, unstaged, and untracked paths.
+
+If any precondition, switch, fast-forward, or verification fails, do not undo the remote merge or mutate around the blocker. Report that the remote merge remains successful, local synchronization is incomplete, the exact blocker, and the safe resume command or condition.
+
+## 10. Preserve and report the worktrees
+
+Leave every linked or managed worktree in place and preserve its branch and contents. Do not delete a branch or worktree, stash, reset, clean, or discard excluded work. Section 9 is the sole exception for checkout movement: it may switch the primary worktree—including the current landing worktree when they are the same—to the verified base branch and fast-forward it.
+
+Report:
+
+- pull-request URL and final state;
+- merge method, approved head, recorded PR head, merge commit, and merge timestamp;
+- landing-worktree path, branch or detached state, local HEAD, upstream, ahead/behind counts, and whether it was also the primary worktree;
+- primary-worktree path, prior/new branches, old/new/remote HEADs, synchronization outcome, and staged, unstaged, and untracked paths;
+- every preserved linked or managed worktree relevant to the landing decision;
+- preserved exclusions and whether the checkout is clean or intentionally dirty;
+- completed stages, explicit omissions, and any follow-up command.
+
+Every stopped report must also name the exact blocker, mutations already performed, stages not performed, and the safest resume point.

--- a/skills/agent-workflows/land/scripts/verify-remote-merge.py
+++ b/skills/agent-workflows/land/scripts/verify-remote-merge.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Verify that an approved PR head produced a recorded integration commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+OBJECT_ID = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+
+
+class VerificationError(RuntimeError):
+    """A fail-closed verification error."""
+
+
+def git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise VerificationError(f"git {' '.join(args)}: {detail}")
+    return result
+
+
+def resolve_commit(repo: Path, value: str, label: str) -> str:
+    result = git(repo, "rev-parse", "--verify", f"{value}^{{commit}}")
+    object_id = result.stdout.strip()
+    if not OBJECT_ID.fullmatch(object_id):
+        raise VerificationError(f"{label} did not resolve to a commit object ID")
+    return object_id
+
+
+def tree(repo: Path, commit: str) -> str:
+    object_id = git(repo, "rev-parse", "--verify", f"{commit}^{{tree}}").stdout.strip()
+    if not OBJECT_ID.fullmatch(object_id):
+        raise VerificationError(f"{commit} did not resolve to a tree object ID")
+    return object_id
+
+
+def parents(repo: Path, commit: str) -> list[str]:
+    output = git(repo, "show", "-s", "--format=%P", commit).stdout.strip()
+    return output.split() if output else []
+
+
+def is_ancestor(repo: Path, older: str, newer: str) -> bool:
+    result = git(repo, "merge-base", "--is-ancestor", older, newer, check=False)
+    if result.returncode not in (0, 1):
+        detail = result.stderr.strip() or "unable to determine ancestry"
+        raise VerificationError(f"git merge-base --is-ancestor: {detail}")
+    return result.returncode == 0
+
+
+def expected_merge_tree(repo: Path, base: str, candidate: str) -> str:
+    result = git(repo, "merge-tree", "--write-tree", base, candidate, check=False)
+    if result.returncode != 0:
+        raise VerificationError(
+            "approved head does not integrate cleanly into the applicable base"
+        )
+    first_line = next((line.strip() for line in result.stdout.splitlines() if line.strip()), "")
+    if not OBJECT_ID.fullmatch(first_line):
+        raise VerificationError("git merge-tree did not return an expected tree object ID")
+    return first_line
+
+
+def verify(
+    repo: Path,
+    method: str,
+    candidate_value: str,
+    validated_base_value: str,
+    integration_value: str,
+) -> dict[str, object]:
+    candidate = resolve_commit(repo, candidate_value, "candidate")
+    validated_base = resolve_commit(repo, validated_base_value, "validated base")
+    integration = resolve_commit(repo, integration_value, "integration")
+    integration_parents = parents(repo, integration)
+
+    if method == "merge":
+        if len(integration_parents) != 2:
+            raise VerificationError("merge integration must have exactly two parents")
+        integration_base = integration_parents[0]
+        if integration_parents[1] != candidate:
+            raise VerificationError(
+                "merge integration's second parent is not the exact approved head"
+            )
+        if not is_ancestor(repo, candidate, integration):
+            raise VerificationError("exact approved head is not an integration ancestor")
+        if not is_ancestor(repo, validated_base, integration_base):
+            raise VerificationError(
+                "actual integration base does not descend from the validated base"
+            )
+    elif method == "squash":
+        if len(integration_parents) != 1:
+            raise VerificationError("squash integration must have exactly one parent")
+        integration_base = integration_parents[0]
+        if not is_ancestor(repo, validated_base, integration_base):
+            raise VerificationError(
+                "actual integration base does not descend from the validated base"
+            )
+    else:
+        integration_base = validated_base
+        if not is_ancestor(repo, validated_base, integration):
+            raise VerificationError(
+                "rebase integration does not descend from the validated base"
+            )
+
+    expected_tree = expected_merge_tree(repo, integration_base, candidate)
+    actual_tree = tree(repo, integration)
+    if expected_tree != actual_tree:
+        raise VerificationError(
+            "recorded integration tree does not equal the expected integration tree"
+        )
+
+    return {
+        "verified": True,
+        "method": method,
+        "candidate_head": candidate,
+        "validated_base": validated_base,
+        "integration_base": integration_base,
+        "integration_commit": integration,
+        "expected_tree": expected_tree,
+        "actual_tree": actual_tree,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--method", choices=("merge", "squash", "rebase"), required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--validated-base", required=True)
+    parser.add_argument("--integration", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = verify(
+            args.repo.resolve(),
+            args.method,
+            args.candidate,
+            args.validated_base,
+            args.integration,
+        )
+    except VerificationError as error:
+        print(json.dumps({"verified": False, "error": str(error)}, sort_keys=True))
+        return 1
+
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`land` lets an agent take approved repository work through atomic commits, pull-request readiness, an exact-head merge, remote verification, and safe primary-worktree synchronization as one controlled workflow. It keeps Compound Engineering, Git, and the GitHub CLI as explicit public prerequisites while failing closed on suspected secrets, stale heads, unknown readiness gates, and unsafe worktree state.

Remote merge verification is method-aware rather than assuming the integrated base tree must equal the pull-request-head tree. The bundled helper accepts newer nonconflicting base changes while rejecting integrations that omit approved content or introduce unapproved content.

## Validation

- Public-skill audit passed with only intentional warnings for the skill's credential-safety language.
- `verify-remote-merge.py` compiled successfully.
- All 7 merge-verifier unit tests passed.
- All 3 bootstrap tests passed.
- Bootstrap catalog, agent-workflow dry run, and targeted `land` dry run all recognized the new skill.

## New concepts

### Method-aware integration-tree verification

An integration commit proves more than “the pull request closed”: it should contain the exact approved change applied to the base GitHub actually integrated. Comparing the final tree directly with the PR head is incorrect whenever the base advanced independently.

| Merge method | Structural anchor | Expected-content check |
|---|---|---|
| Merge commit | Exact approved head is the second parent | Recompute the merge tree against the integration commit's first parent |
| Squash | Integration commit's sole parent | Recompute the merge tree against that actual parent |
| Rebase | Freshly validated base | Recompute the approved change on that validated base |

This preserves legitimate newer base content while detecting dropped candidate content and unapproved additions. It is useful when a workflow must verify the exact integration result; ordinary human inspection does not need this machinery when provenance and content equivalence are not hard gates.
